### PR TITLE
Wrap correct error on raw.Control failure

### DIFF
--- a/peercred_darwin.go
+++ b/peercred_darwin.go
@@ -50,7 +50,7 @@ func getUnix(c *net.UnixConn) (*Creds, error) {
 		}
 	})
 	if cerr != nil {
-		return nil, fmt.Errorf("raw.Control: %w", err)
+		return nil, fmt.Errorf("raw.Control: %w", cerr)
 	}
 	if err != nil {
 		return nil, err

--- a/peercred_linux.go
+++ b/peercred_linux.go
@@ -39,7 +39,7 @@ func getUnix(c *net.UnixConn) (*Creds, error) {
 			unix.SO_PEERCRED)
 	})
 	if cerr != nil {
-		return nil, fmt.Errorf("raw.Control: %w", err)
+		return nil, fmt.Errorf("raw.Control: %w", cerr)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("unix.GetsockoptUcred: %w", err)


### PR DESCRIPTION
Wrap cerr, the error returned by raw.Control.