### PR TITLE
Add GitHub action for CI testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Tests
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - '*'
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.15, 1.16]
+        platform: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Check formatting
+      if: matrix.go-version == '1.16' && matrix.platform == 'ubuntu-latest'
+      run: diff -u <(echo -n) <(go fmt $(go list ./...))
+
+    - name: Run unit tests
+      run: go test -v ./...


### PR DESCRIPTION
Run tests on the currently supported Go versions on Linux and macOS.